### PR TITLE
Fix/junit docer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target/
 
 .checkstyle
 dependency-reduced-pom.xml
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>1.18.8</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
 				<version>3.0.1</version>
 				<configuration>
 					<additionalOptions>-Xdoclint:none</additionalOptions>
+					<source>8</source>
 				</configuration>
 				<executions>
 					<execution>
@@ -228,8 +229,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.4</version>
-			<scope>provided</scope>
+			<version>1.18.8</version>
 		</dependency>
 	</dependencies>
 

--- a/streaming-sparql/pom.xml
+++ b/streaming-sparql/pom.xml
@@ -49,10 +49,10 @@
 
 		<!-- Integration testing -->
 		<dependency>
-			<groupId>com.github.tdomzal</groupId>
-			<artifactId>junit-docker-rule</artifactId>
-			<version>0.4-SNAPSHOT</version>
-			<scope>test</scope>
+   			<groupId>io.github.stephenc.docker</groupId>
+   			<artifactId>junit-docker-rule</artifactId>
+   			<version>0.5.2</version>
+   			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
To get streaming-sparql building locally via mvn, we had to adapt the integration test dependency `junit-docker-rule` from perviously `com.github.tdomzal` (yields a 404 on snapshot repo `https://oss.sonatype.org/content/repositories/snapshots`)  to `io.github.stephenc.docker`.

**Changelog**:
- Upped junit, lombok, junit-docker-rule to latest.
- junit-docker-rule via `io.github.stephenc.docker`
- fixed javadoc to use java version 8