### PR TITLE
fix: pass `query` not `queryString` param in sparql POST

### DIFF
--- a/streaming-sparql/src/main/java/com/weblyzard/sparql/StreamingQueryExecutor.java
+++ b/streaming-sparql/src/main/java/com/weblyzard/sparql/StreamingQueryExecutor.java
@@ -55,7 +55,7 @@ public class StreamingQueryExecutor {
             conn = (HttpURLConnection) new URL(repositoryUrl + "?" + queryString).openConnection();
             setCommonHeaders(conn, timeout);
         } else {
-            conn = openPostConnection(repositoryUrl, queryString, timeout);
+            conn = openPostConnection(repositoryUrl, query, timeout);
         }
 
         // create result set


### PR DESCRIPTION
this solves the http 400 issue encountered with long queries